### PR TITLE
[docs] add `.env` example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,9 @@ HTTP__SESSION_SECRET=
 # ==================================================
 
 # Base URL for the SMS gateway API
-# Default: 'https://sms.capcom.me/api/3rdparty/v1'
-# Example: 'https://sms.capcom.me/api/3rdparty/v1'
-GATEWAY__URL=https://sms.capcom.me/api/3rdparty/v1
+# Default: 'https://api.sms-gate.app/3rdparty/v1'
+# Example: 'https://api.sms-gate.app/3rdparty/v1'
+GATEWAY__URL=https://api.sms-gate.app/3rdparty/v1
 
 # URL where the gateway will send webhook notifications
 # Must match your public server URL

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Create a `.env` file in the project root with the following environment variable
 | ---------------------- | --------------------------------------------------------- | ------------------------------------------------------ |
 | `HTTP__PORT` or `PORT` | Server listening port                                     | `3000`                                                 |
 | `HTTP__SESSION_SECRET` | Session encryption secret                                 | random bytes (32 bytes)                                |
-| `GATEWAY__URL`         | SMS Gateway API URL                                       | `https://sms.capcom.me/api/3rdparty/v1`                |
+| `GATEWAY__URL`         | SMS Gateway API URL                                       | `https://api.sms-gate.app/3rdparty/v1`                 |
 | `GATEWAY__WEBHOOK_URL` | External address for webhooks (`<your-url>/api/webhooks`) | `http://localhost:<your-configured-port>/api/webhooks` |
 | `NODE_ENV`             | Application environment (development or production)       | `production`                                           |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export const http: HttpConfig = {
 }
 
 export const gateway: GatewayConfig = {
-    url: process.env.GATEWAY__URL || "https://sms.capcom.me/api/3rdparty/v1",
+    url: process.env.GATEWAY__URL || "https://api.sms-gate.app/3rdparty/v1",
     webhookUrl: process.env.GATEWAY__WEBHOOK_URL || `http://localhost:${httpPort}/api/webhooks`,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated sample environment and README to reflect the new default SMS gateway host and clarify webhook default behavior.

- Chores
  - Changed the default SMS gateway endpoint to the new service; deployments that set the environment variable explicitly are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->